### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,14 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## Cursor Cloud specific instructions
+
+- **Stack**: Next.js 16.2.4 (App Router, static export), React 19, Tailwind CSS v4, TypeScript, Framer Motion. No database, no backend API.
+- **Node version**: 20+ required. Installed at `/usr/local/bin/node` from binary tarball (not via nvm/nodesource).
+- **Package manager**: npm (lockfile is `package-lock.json`).
+- **Dev server**: `npm run dev` → http://localhost:3000. Hot reloads on file changes.
+- **Lint**: `npm run lint` (ESLint). Note: the repo has pre-existing lint errors (`react-hooks/set-state-in-effect` in `app/template.tsx` and `components/AnimateSection.tsx`); these are not regressions.
+- **Build**: `npm run build` produces static HTML in `./out` (configured via `output: "export"` in `next.config.ts`).
+- **Blog content**: Markdown files in `content/posts/`. Parsed with `gray-matter` + `marked` at build/render time.
+- **No external services**: Fully static site. No Docker, no databases, no API keys needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific development instructions to `AGENTS.md` so future cloud agents can quickly understand the project setup.

### Changes
- Added `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
  - Stack overview (Next.js 16.2.4, React 19, Tailwind v4, TypeScript)
  - Node version requirement (20+)
  - Package manager (npm)
  - Dev/lint/build commands
  - Note about pre-existing lint errors
  - Blog content location
  - Confirmation that no external services are needed

### Dev Environment Verification

All commands verified working:
- `npm install` — dependencies installed successfully
- `npm run lint` — ESLint runs (pre-existing errors noted)
- `npm run build` — static export builds to `./out`
- `npm run dev` — dev server runs at http://localhost:3000

[portfolio_site_navigation_demo.mp4](https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_navigation_demo.mp4)

Demo showing the portfolio site running with navigation through homepage sections and blog pages.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

