### PR TITLE
fix: Blog 深色模式文字配色修正

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -29,22 +29,22 @@ export default async function BlogPostPage({ params }: Props) {
     <div className="max-w-3xl mx-auto px-4 py-16">
       <Link
         href="/blog"
-        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900 transition-colors mb-8"
+        className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 dark:text-gray-400 dark:hover:text-gray-200 transition-colors mb-8"
       >
         <ArrowLeft size={14} />
         Back to Blog
       </Link>
 
       <header className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">{post.title}</h1>
-        <p className="text-sm text-gray-400">{post.date}</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{post.title}</h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{post.date}</p>
         {post.tags && post.tags.length > 0 && (
           <div className="flex items-center gap-1.5 mt-3">
-            <Tag size={12} className="text-gray-400" />
+            <Tag size={12} className="text-gray-400 dark:text-gray-500" />
             {post.tags.map((tag) => (
               <span
                 key={tag}
-                className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"
+                className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-300"
               >
                 {tag}
               </span>
@@ -54,7 +54,7 @@ export default async function BlogPostPage({ params }: Props) {
       </header>
 
       <article
-        className="prose prose-gray max-w-none prose-headings:font-semibold prose-code:text-indigo-600 prose-pre:bg-gray-950 prose-pre:text-gray-100"
+        className="prose prose-gray dark:prose-invert max-w-none prose-headings:font-semibold prose-code:text-indigo-600 dark:prose-code:text-violet-300 prose-pre:bg-gray-950 prose-pre:text-gray-100 prose-a:text-indigo-600 dark:prose-a:text-violet-400 prose-strong:text-gray-900 dark:prose-strong:text-gray-100"
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,37 +13,37 @@ export default function BlogPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-16">
       <div className="flex items-center gap-3 mb-10">
-        <BookOpen size={20} className="text-indigo-600" />
+        <BookOpen size={20} className="text-indigo-600 dark:text-indigo-400" />
         <div>
-          <h1 className="text-xl font-bold text-gray-900">Blog</h1>
-          <p className="text-sm text-gray-500">Frontend engineering notes</p>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">Blog</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Frontend engineering notes</p>
         </div>
       </div>
 
       {posts.length === 0 ? (
-        <p className="text-gray-500 text-sm">No posts yet. Check back soon.</p>
+        <p className="text-gray-500 dark:text-gray-400 text-sm">No posts yet. Check back soon.</p>
       ) : (
         <ul className="space-y-6">
           {posts.map((post) => (
             <li key={post.slug}>
               <Link
                 href={`/blog/${post.slug}`}
-                className="group block rounded-xl border border-gray-200 p-5 hover:border-indigo-200 hover:shadow-sm transition-all"
+                className="group block rounded-xl border border-gray-200 dark:border-gray-700 p-5 hover:border-indigo-200 dark:hover:border-indigo-800 hover:shadow-sm transition-all"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <h2 className="text-base font-semibold text-gray-900 group-hover:text-indigo-600 transition-colors">
+                    <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
                       {post.title}
                     </h2>
-                    <p className="text-xs text-gray-400 mt-0.5 mb-2">{post.date}</p>
-                    <p className="text-sm text-gray-600 leading-relaxed">{post.excerpt}</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 mb-2">{post.date}</p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">{post.excerpt}</p>
                     {post.tags && post.tags.length > 0 && (
                       <div className="flex items-center gap-1.5 mt-3">
-                        <Tag size={12} className="text-gray-400" />
+                        <Tag size={12} className="text-gray-400 dark:text-gray-500" />
                         {post.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500"
+                            className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-300"
                           >
                             {tag}
                           </span>
@@ -53,7 +53,7 @@ export default function BlogPage() {
                   </div>
                   <ArrowRight
                     size={16}
-                    className="flex-shrink-0 mt-1 text-gray-300 group-hover:text-indigo-400 transition-colors"
+                    className="flex-shrink-0 mt-1 text-gray-300 dark:text-gray-600 group-hover:text-indigo-400 transition-colors"
                   />
                 </div>
               </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,3 +30,26 @@ body {
   font-family: var(--font-geist-sans), system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
+
+@media (prefers-color-scheme: dark) {
+  .prose {
+    --tw-prose-body: #d1d5db;
+    --tw-prose-headings: #f3f4f6;
+    --tw-prose-lead: #9ca3af;
+    --tw-prose-links: #a78bfa;
+    --tw-prose-bold: #f3f4f6;
+    --tw-prose-counters: #9ca3af;
+    --tw-prose-bullets: #6b7280;
+    --tw-prose-hr: #374151;
+    --tw-prose-quotes: #d1d5db;
+    --tw-prose-quote-borders: #4b5563;
+    --tw-prose-captions: #9ca3af;
+    --tw-prose-kbd: #f3f4f6;
+    --tw-prose-kbd-shadows: 243 244 246;
+    --tw-prose-code: #c4b5fd;
+    --tw-prose-pre-code: #e5e7eb;
+    --tw-prose-pre-bg: #1f2937;
+    --tw-prose-th-borders: #4b5563;
+    --tw-prose-td-borders: #374151;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

修正 Blog 頁面在深色模式下文字難以閱讀的問題。

### 問題

在 `prefers-color-scheme: dark` 啟用時，Blog 頁面使用了硬編碼的淺色主題文字顏色（如 `text-gray-900`），導致深色背景上的文字幾乎看不見。

### 修復內容

**`globals.css`**
- 新增 `@media (prefers-color-scheme: dark)` 區塊，覆寫 `.prose` 的所有文字色彩變數
- 標題使用 `#f3f4f6`、段落使用 `#d1d5db`、連結使用 `#a78bfa`、行內程式碼使用 `#c4b5fd`

**`app/blog/[slug]/page.tsx`**
- 文章標題加入 `dark:text-gray-100`
- 加入 `dark:prose-invert` 讓整體 prose 內容自動適應深色
- 標籤使用 `dark:bg-gray-800 dark:text-gray-300`
- 連結和 code 使用 violet 色調

**`app/blog/page.tsx`**
- Blog 列表標題、描述、標籤、邊框都加入 `dark:` 變體
- 確保卡片邊框在深色下使用 `dark:border-gray-700`

### 效果

[blog_dark_mode_readability_demo.mp4](https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dark_mode_readability_demo.mp4)

[Blog post in dark mode - title area](https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_dark_mode_title.webp)
[Blog listing in dark mode](https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_listing_dark_mode.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872b9853-3442-4bd4-8b0b-21f3d8f4b019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

