### PR TITLE
TOOLS - Upgrade TypeScript from 5.x to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6503,9 +6503,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrade TypeScript to the latest 6.0.x release while remaining compatible with Next.js 16 and the current typescript-eslint peer range (`<6.1.0`).

## Changes

- Bump `typescript` from `^5` (resolved to 5.9.3) to `^6.0.3`
- Update `package-lock.json` accordingly

## References

- Evaluation: TypeScript 5.9.3 was already the latest 5.x; TS 7 is blocked by typescript-eslint peer (`<6.1.0`)

## Description of the change

> Moves the project onto TypeScript 6.0.3. Next.js 16.2.4 already includes TS 6 compatibility paths, and this repo's `tsconfig` (no `baseUrl`, `moduleResolution: "bundler"`) is TS-6-friendly. TypeScript 7 is deferred until eslint ecosystem peer support lands.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tooling / dependency upgrade

## Related issues

> N/A — dependency maintenance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

