### PR TITLE
BUGFIX - Fix profile image path for GitHub Pages basePath

### DIFF
--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Code2 } from "lucide-react";
 import AnimateSection from "./AnimateSection";
 
@@ -40,13 +41,13 @@ export default function HeroSection() {
           <div className="lg:col-span-4 flex flex-col gap-10">
             <div className="relative inline-block">
               <div className="glass-card w-40 h-40 overflow-hidden transform -rotate-2 hover:rotate-0 transition-transform duration-500 !rounded-3xl">
-                {/* eslint-disable-next-line @next/next/no-img-element -- basePath-aware static asset for GitHub Pages */}
-                <img
+                <Image
                   src={profileSrc}
                   alt="Steven Weng"
                   width={160}
                   height={160}
                   className="w-full h-full object-cover"
+                  priority
                 />
               </div>
               <div className="absolute -bottom-2 -right-2 w-12 h-12 glass-btn-primary rounded-2xl flex items-center justify-center transform rotate-12">

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,6 +1,7 @@
-import Image from "next/image";
 import { Code2 } from "lucide-react";
 import AnimateSection from "./AnimateSection";
+
+const profileSrc = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/profile.jpeg`;
 
 function IconGithub({ size = 22 }: { size?: number }) {
   return (
@@ -39,13 +40,13 @@ export default function HeroSection() {
           <div className="lg:col-span-4 flex flex-col gap-10">
             <div className="relative inline-block">
               <div className="glass-card w-40 h-40 overflow-hidden transform -rotate-2 hover:rotate-0 transition-transform duration-500 !rounded-3xl">
-                <Image
-                  src="/profile.jpeg"
+                {/* eslint-disable-next-line @next/next/no-img-element -- basePath-aware static asset for GitHub Pages */}
+                <img
+                  src={profileSrc}
                   alt="Steven Weng"
                   width={160}
                   height={160}
                   className="w-full h-full object-cover"
-                  priority
                 />
               </div>
               <div className="absolute -bottom-2 -right-2 w-12 h-12 glass-btn-primary rounded-2xl flex items-center justify-center transform rotate-12">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The profile photo was not visible on GitHub Pages because the rendered image `src` pointed to `/profile.jpeg` instead of `/Resume/profile.jpeg`.

## Changes

- Prefix the hero profile image with `NEXT_PUBLIC_BASE_PATH` so it resolves correctly under the `/Resume` base path

## Description of the change

> Confirmed on the live site that CSS/JS used `/Resume/...` correctly, but `next/image` emitted `src="/profile.jpeg"` (404 at site root). The image file itself was already deployed at `/Resume/profile.jpeg`. This change makes the `<Image>` src include the base path.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

