### PR TITLE
BUGFIX - Improve dark mode contrast across Liquid Glass UI

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -44,7 +44,7 @@ export default async function BlogPostPage({ params }: Props) {
             {post.tags.map((tag) => (
               <span
                 key={tag}
-                className="glass-chip text-xs px-2 py-0.5 text-slate-500 dark:text-gray-300"
+                className="glass-chip text-xs px-2 py-0.5 text-slate-600 dark:text-slate-100"
               >
                 {tag}
               </span>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -45,7 +45,7 @@ export default function BlogPage() {
                         {post.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="glass-chip text-xs px-2 py-0.5 text-slate-500 dark:text-gray-300"
+                            className="glass-chip text-xs px-2 py-0.5 text-slate-600 dark:text-slate-100"
                           >
                             {tag}
                           </span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -22,11 +22,11 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #1a1a2e;
-    --foreground: #ededed;
-    --glass-bg: rgba(255, 255, 255, 0.08);
-    --glass-border: rgba(255, 255, 255, 0.15);
-    --glass-shadow: rgba(0, 0, 0, 0.3);
+    --background: #12121f;
+    --foreground: #f3f4f6;
+    --glass-bg: rgba(255, 255, 255, 0.06);
+    --glass-border: rgba(255, 255, 255, 0.16);
+    --glass-shadow: rgba(0, 0, 0, 0.4);
     --glass-highlight: rgba(255, 255, 255, 0.1);
   }
 }
@@ -143,6 +143,51 @@ body::before {
 }
 
 @media (prefers-color-scheme: dark) {
+  body::before {
+    background:
+      radial-gradient(ellipse 60% 50% at 20% 30%, rgba(124, 58, 237, 0.16) 0%, transparent 70%),
+      radial-gradient(ellipse 50% 40% at 80% 60%, rgba(6, 182, 212, 0.1) 0%, transparent 70%),
+      radial-gradient(ellipse 40% 50% at 50% 80%, rgba(236, 72, 153, 0.08) 0%, transparent 70%);
+  }
+
+  .glass-panel-strong {
+    background: rgba(24, 24, 40, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .glass-card {
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .glass-card:hover {
+    background: rgba(255, 255, 255, 0.11);
+    border-color: rgba(255, 255, 255, 0.22);
+    box-shadow:
+      0 12px 40px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  }
+
+  .glass-chip {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .gradient-text-purple {
+    background: linear-gradient(135deg, #c4b5fd, #a78bfa, #ddd6fe);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
   .prose {
     --tw-prose-body: #d1d5db;
     --tw-prose-headings: #f3f4f6;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <Navbar />
         <main className="flex-1">{children}</main>
-        <footer className="glass-panel py-6 text-center text-xs text-slate-500 mt-12">
+        <footer className="glass-panel py-6 text-center text-xs text-slate-500 dark:text-slate-300 mt-12">
           © {new Date().getFullYear()} Steven Weng · Built with Next.js & Tailwind CSS
         </footer>
       </body>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -57,8 +57,8 @@ export default function HeroSection() {
 
             <div className="space-y-8">
               <div className="space-y-4">
-                <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 uppercase tracking-widest">
-                  <div className="h-px w-6 bg-slate-300/50" />
+                <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">
+                  <div className="h-px w-6 bg-slate-300/50 dark:bg-slate-500/60" />
                   Experience
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -71,7 +71,7 @@ export default function HeroSection() {
                   ].map((item) => (
                     <span
                       key={item}
-                      className="glass-chip px-3 py-1 text-xs font-medium text-slate-600"
+                      className="glass-chip px-3 py-1 text-xs font-medium text-slate-700 dark:text-slate-100"
                     >
                       {item}
                     </span>
@@ -80,8 +80,8 @@ export default function HeroSection() {
               </div>
 
               <div className="space-y-4">
-                <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 uppercase tracking-widest">
-                  <div className="h-px w-6 bg-slate-300/50" />
+                <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">
+                  <div className="h-px w-6 bg-slate-300/50 dark:bg-slate-500/60" />
                   Core Stack
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -95,7 +95,7 @@ export default function HeroSection() {
                   ].map((item) => (
                     <span
                       key={item}
-                      className="glass-chip px-3 py-1 text-xs font-semibold text-violet-600"
+                      className="glass-chip px-3 py-1 text-xs font-semibold text-violet-700 dark:text-violet-200"
                     >
                       {item}
                     </span>
@@ -108,7 +108,7 @@ export default function HeroSection() {
                   href="https://github.com/open852134"
                   target="_blank"
                   rel="noreferrer"
-                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-400 hover:text-slate-900 transition-all duration-200"
+                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-500 dark:text-slate-200 hover:text-slate-900 dark:hover:text-white transition-all duration-200"
                   aria-label="GitHub"
                 >
                   <IconGithub size={20} />
@@ -117,7 +117,7 @@ export default function HeroSection() {
                   href="https://www.linkedin.com/in/steven-weng-195348132"
                   target="_blank"
                   rel="noreferrer"
-                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-400 hover:text-blue-600 transition-all duration-200"
+                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-500 dark:text-slate-200 hover:text-blue-600 dark:hover:text-blue-300 transition-all duration-200"
                   aria-label="LinkedIn"
                 >
                   <IconLinkedin size={20} />
@@ -126,7 +126,7 @@ export default function HeroSection() {
                   href="https://www.facebook.com/open852134"
                   target="_blank"
                   rel="noreferrer"
-                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-400 hover:text-blue-500 transition-all duration-200"
+                  className="glass-card w-10 h-10 flex items-center justify-center !rounded-xl text-slate-500 dark:text-slate-200 hover:text-blue-500 dark:hover:text-blue-300 transition-all duration-200"
                   aria-label="Facebook"
                 >
                   <IconFacebook size={20} />
@@ -137,7 +137,7 @@ export default function HeroSection() {
 
           {/* Right Column: Intro Content */}
           <div className="lg:col-span-8 flex flex-col justify-center">
-            <div className="glass-chip inline-flex items-center gap-2 px-3 py-1 text-violet-600 text-[10px] font-bold uppercase tracking-wider mb-6 w-fit">
+            <div className="glass-chip inline-flex items-center gap-2 px-3 py-1 text-violet-700 dark:text-violet-200 text-[10px] font-bold uppercase tracking-wider mb-6 w-fit">
               <span className="relative flex h-2 w-2">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-violet-400 opacity-75"></span>
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-violet-500"></span>
@@ -145,18 +145,18 @@ export default function HeroSection() {
               Available for new projects
             </div>
 
-            <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight text-slate-900 mb-6 leading-[1.1]">
+            <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight text-slate-900 dark:text-white mb-6 leading-[1.1]">
               Hello, I&apos;m <br />
               <span className="gradient-text-purple">
                 Steven Weng
               </span>
             </h1>
 
-            <p className="text-xl text-slate-500 font-medium mb-10 max-w-2xl leading-relaxed">
+            <p className="text-xl text-slate-500 dark:text-slate-300 font-medium mb-10 max-w-2xl leading-relaxed">
               Senior Frontend Engineer focusing on building exceptional digital experiences that are fast, accessible, and visually stunning.
             </p>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8 text-slate-600">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8 text-slate-600 dark:text-slate-300">
               <div className="space-y-4">
                 <p className="leading-relaxed">
                   嗨！ 我是于宸 Steven，目前擔任高階前端工程師。擁有豐富的工業控制系統與網頁開發經驗，專注於 React、TypeScript 以及高效能應用的架構設計。
@@ -165,7 +165,7 @@ export default function HeroSection() {
                   除了開發工作，我也熱衷於社群貢獻，曾參與多場技術年會與社群活動，致力於持續學習最新的前端技術與最佳實踐。
                 </p>
               </div>
-              <div className="glass-card p-6 italic text-sm leading-relaxed text-slate-500">
+              <div className="glass-card p-6 italic text-sm leading-relaxed text-slate-500 dark:text-slate-300">
                 &ldquo;I believe that good design is as little design as possible. Focused on clean code, baseline rhythm, and user-centric solutions.&rdquo;
               </div>
             </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -36,7 +36,7 @@ export default function Navbar() {
           href="/"
           className="flex items-center gap-2 transition-opacity hover:opacity-80"
         >
-          <FileText size={17} className="text-violet-500" />
+          <FileText size={17} className="text-violet-600 dark:text-violet-300" />
           <span className="font-bold text-sm gradient-text-purple tracking-tight">
             Steven Weng
           </span>
@@ -49,7 +49,7 @@ export default function Navbar() {
                 <a
                   key={s.href}
                   href={s.href}
-                  className="px-3 py-1.5 text-sm text-slate-600 hover:text-violet-700 rounded-xl hover:bg-white/40 transition-all duration-200"
+                  className="px-3 py-1.5 text-sm text-slate-600 dark:text-slate-200 hover:text-violet-700 dark:hover:text-violet-300 rounded-xl hover:bg-white/40 dark:hover:bg-white/10 transition-all duration-200"
                 >
                   {s.label}
                 </a>
@@ -58,7 +58,7 @@ export default function Navbar() {
           )}
           <Link
             href="/blog"
-            className="flex items-center gap-1.5 md:ml-1 px-3 py-1.5 text-sm font-medium text-violet-600 hover:text-violet-700 rounded-xl hover:bg-violet-50/60 transition-all duration-200"
+            className="flex items-center gap-1.5 md:ml-1 px-3 py-1.5 text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-800 dark:hover:text-violet-200 rounded-xl hover:bg-violet-50/60 dark:hover:bg-violet-500/15 transition-all duration-200"
           >
             <BookOpen size={14} />
             Blog

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -50,10 +50,10 @@ export default function Projects() {
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 tracking-tight mb-2">專案經驗</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">專案經驗</h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-pink-500 to-violet-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-[0.2em]">Featured Works</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Featured Works</p>
             </div>
           </div>
         </AnimateSection>
@@ -62,20 +62,20 @@ export default function Projects() {
           {PROJECTS.map((project, i) => (
             <AnimateSection key={project.name} delay={i * 0.1}>
               <div className="group h-full glass-card p-6 flex flex-col">
-                <div className="w-12 h-12 rounded-xl bg-white/50 backdrop-blur-sm border border-white/60 flex items-center justify-center text-slate-400 mb-6 group-hover:text-violet-600 transition-colors duration-300">
+                <div className="w-12 h-12 rounded-xl bg-white/50 dark:bg-white/10 backdrop-blur-sm border border-white/60 dark:border-white/20 flex items-center justify-center text-slate-400 dark:text-slate-200 mb-6 group-hover:text-violet-600 dark:group-hover:text-violet-300 transition-colors duration-300">
                   <FolderOpen size={20} />
                 </div>
-                <h3 className="text-lg font-bold text-slate-900 mb-3 tracking-tight group-hover:text-violet-600 transition-colors">
+                <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-3 tracking-tight group-hover:text-violet-600 dark:group-hover:text-violet-300 transition-colors">
                   {project.name}
                 </h3>
-                <p className="text-sm text-slate-500 leading-relaxed mb-6 flex-1">
+                <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed mb-6 flex-1">
                   {project.description}
                 </p>
-                <div className="flex flex-wrap gap-2 pt-4 border-t border-white/30">
+                <div className="flex flex-wrap gap-2 pt-4 border-t border-white/30 dark:border-white/15">
                   {project.tech.map((t) => (
                     <span
                       key={t}
-                      className="glass-chip px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500"
+                      className="glass-chip px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-600 dark:text-slate-200"
                     >
                       {t}
                     </span>

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -44,10 +44,10 @@ export default function Skills() {
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 tracking-tight mb-2">專業技能</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">專業技能</h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-cyan-500 to-violet-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-[0.2em]">Technical Arsenal</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Technical Arsenal</p>
             </div>
           </div>
         </AnimateSection>
@@ -58,10 +58,10 @@ export default function Skills() {
               <div className="group h-full glass-card p-6">
                 <div className="flex items-center justify-between mb-6">
                   <div className="flex flex-col">
-                    <h3 className="text-lg font-bold text-slate-900">{cat.title}</h3>
-                    <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">{cat.subtitle}</span>
+                    <h3 className="text-lg font-bold text-slate-900 dark:text-white">{cat.title}</h3>
+                    <span className="text-[10px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">{cat.subtitle}</span>
                   </div>
-                  <div className="w-10 h-10 rounded-xl bg-white/50 backdrop-blur-sm border border-white/60 flex items-center justify-center text-slate-400 group-hover:text-violet-600 transition-colors duration-300">
+                  <div className="w-10 h-10 rounded-xl bg-white/50 dark:bg-white/10 backdrop-blur-sm border border-white/60 dark:border-white/20 flex items-center justify-center text-slate-400 dark:text-slate-200 group-hover:text-violet-600 dark:group-hover:text-violet-300 transition-colors duration-300">
                     <Layers size={18} />
                   </div>
                 </div>
@@ -69,14 +69,14 @@ export default function Skills() {
                   {cat.items.map((item) => (
                     <span
                       key={item}
-                      className="glass-chip px-3 py-1 text-xs font-semibold text-slate-600"
+                      className="glass-chip px-3 py-1 text-xs font-semibold text-slate-700 dark:text-slate-100"
                     >
                       {item}
                     </span>
                   ))}
                 </div>
-                <div className="pt-4 border-t border-white/30">
-                  <p className="text-sm text-slate-500 leading-relaxed italic">
+                <div className="pt-4 border-t border-white/30 dark:border-white/15">
+                  <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed italic">
                     &ldquo;{cat.note}&rdquo;
                   </p>
                 </div>

--- a/components/WorkExperience.tsx
+++ b/components/WorkExperience.tsx
@@ -122,33 +122,33 @@ export default function WorkExperience() {
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 tracking-tight mb-2">工作經歷</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">工作經歷</h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-violet-500 to-purple-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-[0.2em]">Professional Journey</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Professional Journey</p>
             </div>
           </div>
         </AnimateSection>
 
-        <div className="space-y-12 relative before:absolute before:inset-0 before:ml-5 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-violet-200/50 before:to-transparent">
+        <div className="space-y-12 relative before:absolute before:inset-0 before:ml-5 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-violet-200/50 dark:before:via-violet-500/40 before:to-transparent">
           {JOBS.map((job, i) => (
             <AnimateSection key={job.company} delay={i * 0.1}>
               <div className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
                 {/* Icon */}
-                <div className="flex items-center justify-center w-10 h-10 rounded-full glass-panel text-slate-400 shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 group-[.is-active]:bg-violet-500/80 group-[.is-active]:text-white group-[.is-active]:border-violet-300/50 group-[.is-active]:shadow-violet-200/30 transition-colors duration-500">
+                <div className="flex items-center justify-center w-10 h-10 rounded-full glass-panel text-slate-400 dark:text-slate-200 shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 group-[.is-active]:bg-violet-500/80 group-[.is-active]:text-white group-[.is-active]:border-violet-300/50 group-[.is-active]:shadow-violet-200/30 transition-colors duration-500">
                   <Briefcase size={16} />
                 </div>
                 {/* Content */}
                 <div className="w-[calc(100%-4rem)] md:w-[45%] glass-card p-6">
                   <div className="flex items-center justify-between space-x-2 mb-3">
-                    <div className="font-bold text-slate-900">{job.company}</div>
-                    <time className="font-mono text-[10px] font-bold text-violet-600 glass-chip px-2 py-1">{job.period}</time>
+                    <div className="font-bold text-slate-900 dark:text-white">{job.company}</div>
+                    <time className="font-mono text-[10px] font-bold text-violet-700 dark:text-violet-200 glass-chip px-2 py-1">{job.period}</time>
                   </div>
                   <div className="space-y-4">
                     {job.roles.map((role, idx) => (
-                      <div key={idx} className="relative pl-4 before:absolute before:left-0 before:top-2 before:w-1 before:h-1 before:bg-violet-300 before:rounded-full">
-                        <h4 className="text-sm font-bold text-slate-800 leading-snug">{role.title}</h4>
-                        <p className="text-sm text-slate-500 mt-1 leading-relaxed">{role.description}</p>
+                      <div key={idx} className="relative pl-4 before:absolute before:left-0 before:top-2 before:w-1 before:h-1 before:bg-violet-300 dark:before:bg-violet-400 before:rounded-full">
+                        <h4 className="text-sm font-bold text-slate-800 dark:text-slate-100 leading-snug">{role.title}</h4>
+                        <p className="text-sm text-slate-600 dark:text-slate-300 mt-1 leading-relaxed">{role.description}</p>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dark mode was hard to read on iOS/Safari because glass panels stayed light-theme while text used dark slate/violet colors.

## Changes

- Dark-mode styles for `glass-card`, `glass-chip`, `glass-panel-strong`, and gradient text in `globals.css`
- Add `dark:` text/icon contrast classes across Navbar, Hero, Experience, Skills, Projects, footer, and blog chips

## Description of the change

> PR #5 only fixed blog prose contrast. Homepage Liquid Glass surfaces still rendered light glass overlays with light-theme text classes under `prefers-color-scheme: dark`. This update darkens glass surfaces and brightens text/chips so nav, experience body copy, and tags remain legible.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Follows up on readability gaps left after PR #5 (blog-only dark mode fix)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

