### PR TITLE
NEW FEATURE - Add EN/ZH i18n with static locale routes

### DIFF
--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -1,42 +1,57 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { getAllPostSlugs, getPost, markdownToHtml } from "@/lib/markdown";
 import { ArrowLeft, Tag } from "lucide-react";
+import {
+  getDictionary,
+  isLocale,
+  locales,
+  localizedHref,
+  type Locale,
+} from "@/lib/i18n";
 
 interface Props {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ lang: string; slug: string }>;
 }
 
 export async function generateStaticParams() {
-  return getAllPostSlugs().map((slug) => ({ slug }));
+  const slugs = getAllPostSlugs();
+  return locales.flatMap((lang) => slugs.map((slug) => ({ lang, slug })));
 }
 
-export async function generateMetadata({ params }: Props) {
-  const { slug } = await params;
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang, slug } = await params;
   const post = getPost(slug);
-  if (!post) return {};
+  if (!post || !isLocale(lang)) return {};
   return { title: `${post.title} — Steven Weng`, description: post.excerpt };
 }
 
 export default async function BlogPostPage({ params }: Props) {
-  const { slug } = await params;
+  const { lang, slug } = await params;
+  if (!isLocale(lang)) notFound();
+
+  const locale = lang as Locale;
   const post = getPost(slug);
   if (!post) notFound();
 
+  const dictionary = await getDictionary(locale);
   const html = await markdownToHtml(post.content);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-16">
       <Link
-        href="/blog"
+        href={localizedHref(locale, "/blog")}
         className="inline-flex items-center gap-1.5 text-sm text-slate-500 dark:text-gray-400 hover:text-violet-600 dark:hover:text-gray-200 transition-colors mb-8"
       >
         <ArrowLeft size={14} />
-        Back to Blog
+        {dictionary.blog.back}
       </Link>
 
       <header className="glass-card p-6 mb-8">
-        <h1 className="text-2xl font-bold text-slate-900 dark:text-gray-100 mb-2">{post.title}</h1>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-gray-100 mb-2">
+          {post.title}
+        </h1>
         <p className="text-sm text-slate-400 dark:text-gray-400">{post.date}</p>
         {post.tags && post.tags.length > 0 && (
           <div className="flex items-center gap-1.5 mt-3">

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -1,13 +1,34 @@
 import Link from "next/link";
-import { getAllPosts } from "@/lib/markdown";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { BookOpen, ArrowRight, Tag } from "lucide-react";
+import { getAllPosts } from "@/lib/markdown";
+import { getDictionary, isLocale, localizedHref, type Locale } from "@/lib/i18n";
 
-export const metadata = {
-  title: "Blog — Steven Weng",
-  description: "Writing about React, TypeScript, and frontend engineering.",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  if (!isLocale(lang)) return {};
+  const dictionary = await getDictionary(lang);
+  return {
+    title: dictionary.blog.metaTitle,
+    description: dictionary.blog.metaDescription,
+  };
+}
 
-export default function BlogPage() {
+export default async function BlogPage({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  if (!isLocale(lang)) notFound();
+
+  const locale = lang as Locale;
+  const dictionary = await getDictionary(locale);
   const posts = getAllPosts();
 
   return (
@@ -17,19 +38,23 @@ export default function BlogPage() {
           <BookOpen size={20} className="text-violet-600 dark:text-violet-400" />
         </div>
         <div>
-          <h1 className="text-xl font-bold text-slate-900 dark:text-gray-100">Blog</h1>
-          <p className="text-sm text-slate-500 dark:text-gray-400">Frontend engineering notes</p>
+          <h1 className="text-xl font-bold text-slate-900 dark:text-gray-100">
+            {dictionary.blog.title}
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-gray-400">
+            {dictionary.blog.subtitle}
+          </p>
         </div>
       </div>
 
       {posts.length === 0 ? (
-        <p className="text-slate-500 dark:text-gray-400 text-sm">No posts yet. Check back soon.</p>
+        <p className="text-slate-500 dark:text-gray-400 text-sm">{dictionary.blog.empty}</p>
       ) : (
         <ul className="space-y-6">
           {posts.map((post) => (
             <li key={post.slug}>
               <Link
-                href={`/blog/${post.slug}`}
+                href={localizedHref(locale, `/blog/${post.slug}`)}
                 className="group block glass-card p-5 hover:!bg-white/55 dark:hover:!bg-white/10"
               >
                 <div className="flex items-start justify-between gap-4">
@@ -37,8 +62,12 @@ export default function BlogPage() {
                     <h2 className="text-base font-semibold text-slate-900 dark:text-gray-100 group-hover:text-violet-600 dark:group-hover:text-violet-400 transition-colors">
                       {post.title}
                     </h2>
-                    <p className="text-xs text-slate-400 dark:text-gray-500 mt-0.5 mb-2">{post.date}</p>
-                    <p className="text-sm text-slate-600 dark:text-gray-300 leading-relaxed">{post.excerpt}</p>
+                    <p className="text-xs text-slate-400 dark:text-gray-500 mt-0.5 mb-2">
+                      {post.date}
+                    </p>
+                    <p className="text-sm text-slate-600 dark:text-gray-300 leading-relaxed">
+                      {post.excerpt}
+                    </p>
                     {post.tags && post.tags.length > 0 && (
                       <div className="flex items-center gap-1.5 mt-3">
                         <Tag size={12} className="text-slate-400 dark:text-gray-500" />

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,0 +1,39 @@
+import { notFound } from "next/navigation";
+import Navbar from "@/components/Navbar";
+import SetHtmlLang from "@/components/SetHtmlLang";
+import {
+  getDictionary,
+  isLocale,
+  localeHtmlLang,
+  locales,
+  type Locale,
+} from "@/lib/i18n";
+
+export function generateStaticParams() {
+  return locales.map((lang) => ({ lang }));
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  if (!isLocale(lang)) notFound();
+
+  const locale = lang as Locale;
+  const dictionary = await getDictionary(locale);
+
+  return (
+    <>
+      <SetHtmlLang lang={localeHtmlLang[locale]} />
+      <Navbar locale={locale} labels={dictionary.nav} />
+      <main className="flex-1">{children}</main>
+      <footer className="glass-panel py-6 text-center text-xs text-slate-500 dark:text-slate-300 mt-12">
+        © {new Date().getFullYear()} {dictionary.footer.copyright}
+      </footer>
+    </>
+  );
+}

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import HeroSection from "@/components/HeroSection";
+import WorkExperience from "@/components/WorkExperience";
+import Skills from "@/components/Skills";
+import Projects from "@/components/Projects";
+import { getDictionary, isLocale, type Locale } from "@/lib/i18n";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  if (!isLocale(lang)) return {};
+  const dictionary = await getDictionary(lang);
+  return {
+    title: dictionary.meta.title,
+    description: dictionary.meta.description,
+  };
+}
+
+export default async function HomePage({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  if (!isLocale(lang)) notFound();
+
+  const dictionary = await getDictionary(lang as Locale);
+
+  return (
+    <>
+      <HeroSection copy={dictionary.hero} />
+      <WorkExperience copy={dictionary.experience} />
+      <Skills copy={dictionary.skills} />
+      <Projects copy={dictionary.projects} />
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Navbar from "@/components/Navbar";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,16 +24,11 @@ export default function RootLayout({
 }>) {
   return (
     <html
-      lang="zh-TW"
+      lang="en"
+      suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col bg-background text-foreground">
-        <Navbar />
-        <main className="flex-1">{children}</main>
-        <footer className="glass-panel py-6 text-center text-xs text-slate-500 dark:text-slate-300 mt-12">
-          © {new Date().getFullYear()} Steven Weng · Built with Next.js & Tailwind CSS
-        </footer>
-      </body>
+      <body className="min-h-full flex flex-col bg-background text-foreground">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,25 @@
-import HeroSection from "@/components/HeroSection";
-import WorkExperience from "@/components/WorkExperience";
-import Skills from "@/components/Skills";
-import Projects from "@/components/Projects";
+import Link from "next/link";
+import { defaultLocale, localizedHref } from "@/lib/i18n";
 
-export default function HomePage() {
+export default function RootPage() {
+  const href = localizedHref(defaultLocale, "/");
+  const refreshTarget = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/${defaultLocale}/`;
+
   return (
-    <>
-      <HeroSection />
-      <WorkExperience />
-      <Skills />
-      <Projects />
-    </>
+    <main className="min-h-[50vh] flex flex-col items-center justify-center gap-4 px-6 text-center">
+      <meta httpEquiv="refresh" content={`0; url=${refreshTarget}`} />
+      <p className="text-slate-600 dark:text-slate-300 text-sm">Redirecting to English…</p>
+      <Link
+        href={href}
+        className="text-violet-700 dark:text-violet-300 font-medium underline underline-offset-4"
+      >
+        Continue to English site
+      </Link>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.location.replace(${JSON.stringify(refreshTarget)});`,
+        }}
+      />
+    </main>
   );
 }

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { Code2 } from "lucide-react";
 import AnimateSection from "./AnimateSection";
+import type { Dictionary } from "@/dictionaries/types";
 
 const profileSrc = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/profile.jpeg`;
 
@@ -28,22 +29,20 @@ function IconFacebook({ size = 22 }: { size?: number }) {
   );
 }
 
-export default function HeroSection() {
+export default function HeroSection({ copy }: { copy: Dictionary["hero"] }) {
   return (
     <section id="about" className="max-w-5xl mx-auto px-6 py-24 sm:py-32 relative">
-      {/* Background orbs */}
       <div className="gradient-orb w-72 h-72 bg-violet-400/20 top-10 -left-20" />
       <div className="gradient-orb w-56 h-56 bg-cyan-400/15 bottom-20 right-0" />
 
       <AnimateSection>
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-16 items-start relative z-10">
-          {/* Left Column: Profile & Sidebar */}
           <div className="lg:col-span-4 flex flex-col gap-10">
             <div className="relative inline-block">
               <div className="glass-card w-40 h-40 overflow-hidden transform -rotate-2 hover:rotate-0 transition-transform duration-500 !rounded-3xl">
                 <Image
                   src={profileSrc}
-                  alt="Steven Weng"
+                  alt={copy.photoAlt}
                   width={160}
                   height={160}
                   className="w-full h-full object-cover"
@@ -59,16 +58,10 @@ export default function HeroSection() {
               <div className="space-y-4">
                 <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">
                   <div className="h-px w-6 bg-slate-300/50 dark:bg-slate-500/60" />
-                  Experience
+                  {copy.experienceLabel}
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {[
-                    "Placements.io",
-                    "4IDPS",
-                    "三商電腦",
-                    "鵬柏科技",
-                    "專智科技",
-                  ].map((item) => (
+                  {copy.companies.map((item) => (
                     <span
                       key={item}
                       className="glass-chip px-3 py-1 text-xs font-medium text-slate-700 dark:text-slate-100"
@@ -82,17 +75,10 @@ export default function HeroSection() {
               <div className="space-y-4">
                 <div className="flex items-center gap-3 text-[11px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">
                   <div className="h-px w-6 bg-slate-300/50 dark:bg-slate-500/60" />
-                  Core Stack
+                  {copy.coreStackLabel}
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {[
-                    "React",
-                    "TypeScript",
-                    "Node.js",
-                    "Next.js",
-                    "C#",
-                    "Tailwind",
-                  ].map((item) => (
+                  {copy.stack.map((item) => (
                     <span
                       key={item}
                       className="glass-chip px-3 py-1 text-xs font-semibold text-violet-700 dark:text-violet-200"
@@ -135,38 +121,34 @@ export default function HeroSection() {
             </div>
           </div>
 
-          {/* Right Column: Intro Content */}
           <div className="lg:col-span-8 flex flex-col justify-center">
             <div className="glass-chip inline-flex items-center gap-2 px-3 py-1 text-violet-700 dark:text-violet-200 text-[10px] font-bold uppercase tracking-wider mb-6 w-fit">
               <span className="relative flex h-2 w-2">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-violet-400 opacity-75"></span>
                 <span className="relative inline-flex rounded-full h-2 w-2 bg-violet-500"></span>
               </span>
-              Available for new projects
+              {copy.available}
             </div>
 
             <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight text-slate-900 dark:text-white mb-6 leading-[1.1]">
-              Hello, I&apos;m <br />
-              <span className="gradient-text-purple">
-                Steven Weng
-              </span>
+              {copy.greeting} <br />
+              <span className="gradient-text-purple">{copy.name}</span>
             </h1>
 
             <p className="text-xl text-slate-500 dark:text-slate-300 font-medium mb-10 max-w-2xl leading-relaxed">
-              Senior Frontend Engineer focusing on building exceptional digital experiences that are fast, accessible, and visually stunning.
+              {copy.tagline}
             </p>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 text-slate-600 dark:text-slate-300">
               <div className="space-y-4">
-                <p className="leading-relaxed">
-                  嗨！ 我是于宸 Steven，目前擔任高階前端工程師。擁有豐富的工業控制系統與網頁開發經驗，專注於 React、TypeScript 以及高效能應用的架構設計。
-                </p>
-                <p className="leading-relaxed">
-                  除了開發工作，我也熱衷於社群貢獻，曾參與多場技術年會與社群活動，致力於持續學習最新的前端技術與最佳實踐。
-                </p>
+                {copy.bio.map((paragraph) => (
+                  <p key={paragraph.slice(0, 24)} className="leading-relaxed">
+                    {paragraph}
+                  </p>
+                ))}
               </div>
               <div className="glass-card p-6 italic text-sm leading-relaxed text-slate-500 dark:text-slate-300">
-                &ldquo;I believe that good design is as little design as possible. Focused on clean code, baseline rhythm, and user-centric solutions.&rdquo;
+                &ldquo;{copy.quote}&rdquo;
               </div>
             </div>
           </div>

--- a/components/LocaleToggle.tsx
+++ b/components/LocaleToggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { Locale } from "@/lib/i18n";
+import { locales, swapLocaleInPathname } from "@/lib/i18n";
+
+interface LocaleToggleProps {
+  locale: Locale;
+  labels: {
+    en: string;
+    zh: string;
+  };
+}
+
+export default function LocaleToggle({ locale, labels }: LocaleToggleProps) {
+  const pathname = usePathname() || "/";
+
+  return (
+    <div
+      className="flex items-center rounded-xl border border-white/40 dark:border-white/15 bg-white/30 dark:bg-white/5 p-0.5 text-xs font-semibold"
+      role="group"
+      aria-label="Language"
+    >
+      {locales.map((item) => {
+        const active = item === locale;
+        const href = swapLocaleInPathname(pathname, item);
+        const label = item === "en" ? labels.en : labels.zh;
+        return (
+          <Link
+            key={item}
+            href={href}
+            className={`px-2.5 py-1 rounded-lg transition-colors ${
+              active
+                ? "bg-violet-600 text-white dark:bg-violet-500"
+                : "text-slate-600 dark:text-slate-200 hover:text-violet-700 dark:hover:text-violet-200"
+            }`}
+            aria-current={active ? "page" : undefined}
+            hrefLang={item === "zh" ? "zh-TW" : "en"}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,18 +4,31 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FileText, BookOpen } from "lucide-react";
+import LocaleToggle from "./LocaleToggle";
+import type { Locale } from "@/lib/i18n";
+import { localizedHref } from "@/lib/i18n";
+import type { Dictionary } from "@/dictionaries/types";
 
-const NAV_SECTIONS = [
-  { href: "#about", label: "About" },
-  { href: "#experience", label: "Experience" },
-  { href: "#skills", label: "Skills" },
-  { href: "#projects", label: "Projects" },
-];
+interface NavbarProps {
+  locale: Locale;
+  labels: Dictionary["nav"];
+}
 
-export default function Navbar() {
-  const pathname = usePathname();
-  const isHome = pathname === "/";
+export default function Navbar({ locale, labels }: NavbarProps) {
+  const pathname = usePathname() || "/";
+  const homeHref = localizedHref(locale, "/");
+  const isHome =
+    pathname === homeHref ||
+    pathname === `/${locale}` ||
+    pathname === `/${locale}/`;
   const [scrolled, setScrolled] = useState(false);
+
+  const sections = [
+    { href: `${homeHref}#about`, label: labels.about },
+    { href: `${homeHref}#experience`, label: labels.experience },
+    { href: `${homeHref}#skills`, label: labels.skills },
+    { href: `${homeHref}#projects`, label: labels.projects },
+  ];
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 12);
@@ -26,43 +39,45 @@ export default function Navbar() {
   return (
     <header
       className={`sticky top-4 z-50 mx-auto w-[calc(100%-2rem)] max-w-5xl transition-all duration-500 rounded-2xl ${
-        scrolled
-          ? "glass-panel-strong shadow-lg"
-          : "bg-transparent"
+        scrolled ? "glass-panel-strong shadow-lg" : "bg-transparent"
       }`}
     >
-      <nav className="px-5 h-14 flex items-center justify-between">
+      <nav className="px-5 h-14 flex items-center justify-between gap-3">
         <Link
-          href="/"
-          className="flex items-center gap-2 transition-opacity hover:opacity-80"
+          href={homeHref}
+          className="flex items-center gap-2 transition-opacity hover:opacity-80 min-w-0"
         >
-          <FileText size={17} className="text-violet-600 dark:text-violet-300" />
-          <span className="font-bold text-sm gradient-text-purple tracking-tight">
-            Steven Weng
+          <FileText size={17} className="text-violet-600 dark:text-violet-300 shrink-0" />
+          <span className="font-bold text-sm gradient-text-purple tracking-tight truncate">
+            {labels.brand}
           </span>
         </Link>
 
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center gap-1 sm:gap-2">
           {isHome && (
             <div className="hidden md:flex items-center gap-0.5">
-              {NAV_SECTIONS.map((s) => (
+              {sections.map((section) => (
                 <a
-                  key={s.href}
-                  href={s.href}
+                  key={section.href}
+                  href={section.href}
                   className="px-3 py-1.5 text-sm text-slate-600 dark:text-slate-200 hover:text-violet-700 dark:hover:text-violet-300 rounded-xl hover:bg-white/40 dark:hover:bg-white/10 transition-all duration-200"
                 >
-                  {s.label}
+                  {section.label}
                 </a>
               ))}
             </div>
           )}
           <Link
-            href="/blog"
-            className="flex items-center gap-1.5 md:ml-1 px-3 py-1.5 text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-800 dark:hover:text-violet-200 rounded-xl hover:bg-violet-50/60 dark:hover:bg-violet-500/15 transition-all duration-200"
+            href={localizedHref(locale, "/blog")}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-800 dark:hover:text-violet-200 rounded-xl hover:bg-violet-50/60 dark:hover:bg-violet-500/15 transition-all duration-200"
           >
             <BookOpen size={14} />
-            Blog
+            {labels.blog}
           </Link>
+          <LocaleToggle
+            locale={locale}
+            labels={{ en: labels.localeEn, zh: labels.localeZh }}
+          />
         </div>
       </nav>
     </header>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,65 +1,30 @@
 import { FolderOpen } from "lucide-react";
 import AnimateSection from "./AnimateSection";
+import type { Dictionary } from "@/dictionaries/types";
 
-interface Project {
-  name: string;
-  description: string;
-  tech: string[];
-}
-
-const PROJECTS: Project[] = [
-  {
-    name: "太陽人全民電廠",
-    description:
-      "使用 C# ASP.NET WebForm 架構開發，建置太陽能購買平台，串接金流服務，支援信用卡及 ATM 轉帳。",
-    tech: ["C# ASP.NET WebForm", "HTML5", "CSS3", "MSSQL", "智付通金流", "Google Cloud", "Win Server"],
-  },
-  {
-    name: "DMS 提款機監控 + 入金機後台翻新",
-    description:
-      "協助將 ASP 舊專案更新至 ASP.NET，重新設計 HTML5 前端介面，並優化 SQL Stored Procedure 查詢效能。",
-    tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "CSS3", "jQuery"],
-  },
-  {
-    name: "Relay 驛站停車場 — 形象網站",
-    description:
-      "純前端客製化響應式形象網站，使用 HTML5、CSS3、JavaScript 開發。",
-    tech: ["HTML5", "CSS3", "JavaScript", "jQuery"],
-  },
-  {
-    name: "豪運租賃 — 形象網站",
-    description:
-      "使用 C# ASP.NET WebForm 建置前端形象網站，含後台供客戶自行編輯頁面內容，架設於 AWS 雲端。",
-    tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "jQuery", "AWS Cloud"],
-  },
-  {
-    name: "紙捲自動化噴印系統",
-    description:
-      "使用 C# WinForm 開發工業控制自動流程，配合 PLC 及各類 Sensor 獲取資料，整合至系統產生報表與生產履歷。",
-    tech: ["C# WinForm", "MSSQL", "MySQL", "SQLite", "SAP ERP", "PLC"],
-  },
-];
-
-export default function Projects() {
+export default function Projects({ copy }: { copy: Dictionary["projects"] }) {
   return (
     <section id="projects" className="py-24 sm:py-32 relative">
-      {/* Background orbs */}
       <div className="gradient-orb w-64 h-64 bg-pink-400/10 top-32 left-10" />
       <div className="gradient-orb w-48 h-48 bg-violet-400/10 bottom-20 right-20" />
 
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">專案經驗</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">
+              {copy.title}
+            </h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-pink-500 to-violet-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Featured Works</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">
+                {copy.subtitle}
+              </p>
             </div>
           </div>
         </AnimateSection>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {PROJECTS.map((project, i) => (
+          {copy.items.map((project, i) => (
             <AnimateSection key={project.name} delay={i * 0.1}>
               <div className="group h-full glass-card p-6 flex flex-col">
                 <div className="w-12 h-12 rounded-xl bg-white/50 dark:bg-white/10 backdrop-blur-sm border border-white/60 dark:border-white/20 flex items-center justify-center text-slate-400 dark:text-slate-200 mb-6 group-hover:text-violet-600 dark:group-hover:text-violet-300 transition-colors duration-300">
@@ -72,12 +37,12 @@ export default function Projects() {
                   {project.description}
                 </p>
                 <div className="flex flex-wrap gap-2 pt-4 border-t border-white/30 dark:border-white/15">
-                  {project.tech.map((t) => (
+                  {project.tech.map((tech) => (
                     <span
-                      key={t}
+                      key={tech}
                       className="glass-chip px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-600 dark:text-slate-200"
                     >
-                      {t}
+                      {tech}
                     </span>
                   ))}
                 </div>

--- a/components/SetHtmlLang.tsx
+++ b/components/SetHtmlLang.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function SetHtmlLang({ lang }: { lang: string }) {
+  useEffect(() => {
+    document.documentElement.lang = lang;
+  }, [lang]);
+
+  return null;
+}

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -1,65 +1,37 @@
 import { Layers } from "lucide-react";
 import AnimateSection from "./AnimateSection";
+import type { Dictionary } from "@/dictionaries/types";
 
-interface SkillCategory {
-  title: string;
-  subtitle: string;
-  items: string[];
-  note: string;
-}
-
-const SKILLS: SkillCategory[] = [
-  {
-    title: "網頁前端",
-    subtitle: "Frontend",
-    items: ["React + Redux (Redux Thunk)", "HTML5", "CSS3 (SCSS)", "JavaScript", "jQuery", "Vue.js"],
-    note: "近一年半多專注於前端開發。本身也喜歡閱讀 UI/UX 相關文章，提升設計美感。",
-  },
-  {
-    title: "網頁後端",
-    subtitle: "Backend",
-    items: ["C# (WinForm · WebForm · MVC)", "PHP (CodeIgniter)", "Node.js"],
-    note: "開發過電商網站，串接過金流（智付通、歐付寶）。",
-  },
-  {
-    title: "資料庫 · 系統",
-    subtitle: "Database & Systems",
-    items: ["MySQL", "MSSQL", "MongoDB", "Windows Server", "Linux (Ubuntu · Fedora)"],
-    note: "兩大平台都有接觸，包含服務的架設部署。",
-  },
-  {
-    title: "其他",
-    subtitle: "Others",
-    items: ["PhoneGap", "ChatBot", "Adobe Illustrator", "Adobe Photoshop"],
-    note: "玩過 Chatbot 聊天機器人，也修過 Illustrator、Photoshop 設計相關課程。",
-  },
-];
-
-export default function Skills() {
+export default function Skills({ copy }: { copy: Dictionary["skills"] }) {
   return (
     <section id="skills" className="py-24 sm:py-32 relative">
-      {/* Background orb */}
       <div className="gradient-orb w-80 h-80 bg-cyan-400/10 top-20 right-10" />
 
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">專業技能</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">
+              {copy.title}
+            </h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-cyan-500 to-violet-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Technical Arsenal</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">
+                {copy.subtitle}
+              </p>
             </div>
           </div>
         </AnimateSection>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {SKILLS.map((cat, i) => (
+          {copy.categories.map((cat, i) => (
             <AnimateSection key={cat.title} delay={i * 0.1}>
               <div className="group h-full glass-card p-6">
                 <div className="flex items-center justify-between mb-6">
                   <div className="flex flex-col">
                     <h3 className="text-lg font-bold text-slate-900 dark:text-white">{cat.title}</h3>
-                    <span className="text-[10px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">{cat.subtitle}</span>
+                    <span className="text-[10px] font-bold text-slate-400 dark:text-slate-300 uppercase tracking-widest">
+                      {cat.subtitle}
+                    </span>
                   </div>
                   <div className="w-10 h-10 rounded-xl bg-white/50 dark:bg-white/10 backdrop-blur-sm border border-white/60 dark:border-white/20 flex items-center justify-center text-slate-400 dark:text-slate-200 group-hover:text-violet-600 dark:group-hover:text-violet-300 transition-colors duration-300">
                     <Layers size={18} />

--- a/components/WorkExperience.tsx
+++ b/components/WorkExperience.tsx
@@ -1,154 +1,53 @@
 import { Briefcase } from "lucide-react";
 import AnimateSection from "./AnimateSection";
+import type { Dictionary } from "@/dictionaries/types";
 
-interface Job {
-  period: string;
-  company: string;
-  roles: { title: string; description: string }[];
-}
-
-const JOBS: Job[] = [
-  {
-    period: "2020.09 — 2026.03",
-    company: "Placements.io",
-    roles: [
-      {
-        title: "Senior Frontend Engineer",
-        description:
-          "Lead frontend architecture decisions across the revenue management platform, establishing patterns for scalable, maintainable React applications used by enterprise clients.",
-      },
-      {
-        title: "Large-Scale Data Dashboard Optimization",
-        description:
-          "Designed and optimized high-performance dashboards handling millions of ad spend records, reducing load times by leveraging virtualization, memoization, and efficient API pagination.",
-      },
-      {
-        title: "Mentorship & Team Development",
-        description:
-          "Mentor junior and mid-level engineers through code reviews, pair programming sessions, and internal tech talks on React, TypeScript, and frontend best practices.",
-      },
-      {
-        title: "Cross-Functional Collaboration",
-        description:
-          "Partner closely with product, design, and backend teams to deliver end-to-end features — from API contract design to pixel-perfect UI implementation and QA sign-off.",
-      },
-    ],
-  },
-  {
-    period: "2018.12 — 2020.09",
-    company: "4IDPS 我愛數位科技",
-    roles: [
-      {
-        title: "獨立負責 MES 系統開發",
-        description:
-          "包含系統規劃、設計、執行。技術使用 NodeJS + Oracle 搭配前端 React + Redux。",
-      },
-      {
-        title: "負責 Nextmile 網站前後端開發",
-        description:
-          "技術包含：AWS Serverless (Amplify, DynamoDB, AppSync, S3), React + GraphQL。",
-      },
-      {
-        title: "負責 LevelHeroes 網站前端開發",
-        description:
-          "技術包含：React, CSS-in-JS (Styled Components), Hooks, Storybook。",
-      },
-      {
-        title: "內部訓練經驗分享",
-        description:
-          "CSS、React、JavaScript 等技術分享，以及專案經驗分享。",
-      },
-    ],
-  },
-  {
-    period: "2017-08 — 2018-12",
-    company: "三商電腦",
-    roles: [
-      {
-        title: "入金系統專案維護與需求開發",
-        description:
-          "包含 ASP.NET 維護、排程作業維護、MSSQL Stored Procedure 維護更新及備份。",
-      },
-      {
-        title: "ATM 監控系統翻新",
-        description: "協助將 ASP 舊專案升級至 ASP.NET。",
-      },
-      {
-        title: "導入前後端分離架構",
-        description:
-          "協助評估 VueJS，進行基礎教育訓練，建置前後端分離的開發架構。",
-      },
-    ],
-  },
-  {
-    period: "2016-03 — 2017-08",
-    company: "鵬柏科技",
-    roles: [
-      {
-        title: "台中正隆紙廠產線自動化系統開發",
-        description:
-          "使用 C# 開發桌面程式及硬體通訊程式，整合 SAP ERP 系統達到自動生產入庫。",
-      },
-      {
-        title: "印尼 Fajar Paper 紙廠自動化系統開發",
-        description: "負責兩套程式開發以及印尼現場作業規劃、會議進行。",
-      },
-      {
-        title: "蘇花改灌漿機程式開發",
-        description:
-          "使用 C# 串接印表機及 Sensor 設備，紀錄灌漿資料至 SQLite 並即時列印數據。",
-      },
-    ],
-  },
-  {
-    period: "2014 — 2015",
-    company: "專智科技",
-    roles: [
-      {
-        title: "電商網站維護",
-        description:
-          "接觸正在運行的 VB.NET / PHP 專案，學習 Linux 伺服器架設、CRM 系統維護、前端 jQuery 開發及 PhoneGap APP 開發。",
-      },
-    ],
-  },
-];
-
-export default function WorkExperience() {
+export default function WorkExperience({ copy }: { copy: Dictionary["experience"] }) {
   return (
     <section id="experience" className="py-24 sm:py-32 relative">
-      {/* Background orb */}
       <div className="gradient-orb w-96 h-96 bg-purple-400/10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
 
       <div className="max-w-5xl mx-auto px-6 relative z-10">
         <AnimateSection>
           <div className="flex flex-col mb-16">
-            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">工作經歷</h2>
+            <h2 className="text-3xl font-extrabold text-slate-900 dark:text-white tracking-tight mb-2">
+              {copy.title}
+            </h2>
             <div className="flex items-center gap-3">
               <div className="h-1 w-12 bg-gradient-to-r from-violet-500 to-purple-500 rounded-full" />
-              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">Professional Journey</p>
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-300 uppercase tracking-[0.2em]">
+                {copy.subtitle}
+              </p>
             </div>
           </div>
         </AnimateSection>
 
         <div className="space-y-12 relative before:absolute before:inset-0 before:ml-5 before:-translate-x-px md:before:mx-auto md:before:translate-x-0 before:h-full before:w-0.5 before:bg-gradient-to-b before:from-transparent before:via-violet-200/50 dark:before:via-violet-500/40 before:to-transparent">
-          {JOBS.map((job, i) => (
-            <AnimateSection key={job.company} delay={i * 0.1}>
+          {copy.jobs.map((job, i) => (
+            <AnimateSection key={`${job.company}-${job.period}`} delay={i * 0.1}>
               <div className="relative flex items-center justify-between md:justify-normal md:odd:flex-row-reverse group is-active">
-                {/* Icon */}
                 <div className="flex items-center justify-center w-10 h-10 rounded-full glass-panel text-slate-400 dark:text-slate-200 shrink-0 md:order-1 md:group-odd:-translate-x-1/2 md:group-even:translate-x-1/2 group-[.is-active]:bg-violet-500/80 group-[.is-active]:text-white group-[.is-active]:border-violet-300/50 group-[.is-active]:shadow-violet-200/30 transition-colors duration-500">
                   <Briefcase size={16} />
                 </div>
-                {/* Content */}
                 <div className="w-[calc(100%-4rem)] md:w-[45%] glass-card p-6">
                   <div className="flex items-center justify-between space-x-2 mb-3">
                     <div className="font-bold text-slate-900 dark:text-white">{job.company}</div>
-                    <time className="font-mono text-[10px] font-bold text-violet-700 dark:text-violet-200 glass-chip px-2 py-1">{job.period}</time>
+                    <time className="font-mono text-[10px] font-bold text-violet-700 dark:text-violet-200 glass-chip px-2 py-1">
+                      {job.period}
+                    </time>
                   </div>
                   <div className="space-y-4">
-                    {job.roles.map((role, idx) => (
-                      <div key={idx} className="relative pl-4 before:absolute before:left-0 before:top-2 before:w-1 before:h-1 before:bg-violet-300 dark:before:bg-violet-400 before:rounded-full">
-                        <h4 className="text-sm font-bold text-slate-800 dark:text-slate-100 leading-snug">{role.title}</h4>
-                        <p className="text-sm text-slate-600 dark:text-slate-300 mt-1 leading-relaxed">{role.description}</p>
+                    {job.roles.map((role) => (
+                      <div
+                        key={role.title}
+                        className="relative pl-4 before:absolute before:left-0 before:top-2 before:w-1 before:h-1 before:bg-violet-300 dark:before:bg-violet-400 before:rounded-full"
+                      >
+                        <h4 className="text-sm font-bold text-slate-800 dark:text-slate-100 leading-snug">
+                          {role.title}
+                        </h4>
+                        <p className="text-sm text-slate-600 dark:text-slate-300 mt-1 leading-relaxed">
+                          {role.description}
+                        </p>
                       </div>
                     ))}
                   </div>

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -1,0 +1,247 @@
+import type { Dictionary } from "./types";
+
+const en: Dictionary = {
+  meta: {
+    title: "Steven Weng — Frontend Engineer",
+    description:
+      "Portfolio and blog of Steven Weng (翁于宸), Senior Frontend Engineer.",
+  },
+  nav: {
+    brand: "Steven Weng",
+    about: "About",
+    experience: "Experience",
+    skills: "Skills",
+    projects: "Projects",
+    blog: "Blog",
+    localeEn: "EN",
+    localeZh: "中文",
+  },
+  footer: {
+    copyright: "Steven Weng · Built with Next.js & Tailwind CSS",
+  },
+  hero: {
+    experienceLabel: "Experience",
+    coreStackLabel: "Core Stack",
+    available: "Available for new projects",
+    greeting: "Hello, I'm",
+    name: "Steven Weng",
+    tagline:
+      "Senior Frontend Engineer focusing on building exceptional digital experiences that are fast, accessible, and visually stunning.",
+    bio: [
+      "Hi! I'm Steven (于宸). I'm a senior frontend engineer with deep experience in industrial control systems and web development, focused on React, TypeScript, and high-performance application architecture.",
+      "Beyond day-to-day engineering, I enjoy community work — speaking at and joining tech conferences and meetups, and continuously learning modern frontend practices.",
+    ],
+    quote:
+      "I believe that good design is as little design as possible. Focused on clean code, baseline rhythm, and user-centric solutions.",
+    companies: ["Placements.io", "4IDPS", "Mercuries Data Systems", "Pengbo Tech", "Zhuanzhi Tech"],
+    stack: ["React", "TypeScript", "Node.js", "Next.js", "C#", "Tailwind"],
+    photoAlt: "Steven Weng",
+  },
+  experience: {
+    title: "Work Experience",
+    subtitle: "Professional Journey",
+    jobs: [
+      {
+        period: "2020.09 — 2026.03",
+        company: "Placements.io",
+        roles: [
+          {
+            title: "Senior Frontend Engineer",
+            description:
+              "Lead frontend architecture decisions across the revenue management platform, establishing patterns for scalable, maintainable React applications used by enterprise clients.",
+          },
+          {
+            title: "Large-Scale Data Dashboard Optimization",
+            description:
+              "Designed and optimized high-performance dashboards handling millions of ad spend records, reducing load times by leveraging virtualization, memoization, and efficient API pagination.",
+          },
+          {
+            title: "Mentorship & Team Development",
+            description:
+              "Mentor junior and mid-level engineers through code reviews, pair programming sessions, and internal tech talks on React, TypeScript, and frontend best practices.",
+          },
+          {
+            title: "Cross-Functional Collaboration",
+            description:
+              "Partner closely with product, design, and backend teams to deliver end-to-end features — from API contract design to pixel-perfect UI implementation and QA sign-off.",
+          },
+        ],
+      },
+      {
+        period: "2018.12 — 2020.09",
+        company: "4IDPS",
+        roles: [
+          {
+            title: "Owned MES system development end-to-end",
+            description:
+              "Covered planning, design, and delivery using Node.js + Oracle with a React + Redux frontend.",
+          },
+          {
+            title: "Nextmile full-stack web development",
+            description:
+              "Built with AWS Serverless (Amplify, DynamoDB, AppSync, S3) and React + GraphQL.",
+          },
+          {
+            title: "LevelHeroes frontend development",
+            description:
+              "React, CSS-in-JS (Styled Components), Hooks, and Storybook.",
+          },
+          {
+            title: "Internal tech sharing",
+            description:
+              "Shared CSS, React, JavaScript practices and project learnings with the team.",
+          },
+        ],
+      },
+      {
+        period: "2017-08 — 2018-12",
+        company: "Mercuries Data Systems",
+        roles: [
+          {
+            title: "Cash deposit system maintenance & feature work",
+            description:
+              "ASP.NET maintenance, scheduled jobs, and MSSQL stored procedure updates and backups.",
+          },
+          {
+            title: "ATM monitoring system refresh",
+            description: "Helped migrate a legacy ASP project to ASP.NET.",
+          },
+          {
+            title: "Adopted frontend/backend separation",
+            description:
+              "Evaluated Vue.js, ran baseline training, and established a separated FE/BE architecture.",
+          },
+        ],
+      },
+      {
+        period: "2016-03 — 2017-08",
+        company: "Pengbo Tech",
+        roles: [
+          {
+            title: "Cheng Long Paper (Taichung) production-line automation",
+            description:
+              "Built C# desktop and hardware communication software integrated with SAP ERP for automated production inbound.",
+          },
+          {
+            title: "Fajar Paper (Indonesia) automation systems",
+            description:
+              "Delivered two applications and coordinated on-site planning and meetings in Indonesia.",
+          },
+          {
+            title: "Suhua Highway improvement grouting machine software",
+            description:
+              "Used C# to integrate printers and sensors, store grouting data in SQLite, and print metrics in real time.",
+          },
+        ],
+      },
+      {
+        period: "2014 — 2015",
+        company: "Zhuanzhi Tech",
+        roles: [
+          {
+            title: "E-commerce site maintenance",
+            description:
+              "Worked on live VB.NET / PHP projects while learning Linux server setup, CRM maintenance, frontend jQuery, and PhoneGap apps.",
+          },
+        ],
+      },
+    ],
+  },
+  skills: {
+    title: "Skills",
+    subtitle: "Technical Arsenal",
+    categories: [
+      {
+        title: "Frontend",
+        subtitle: "Web Frontend",
+        items: [
+          "React + Redux (Redux Thunk)",
+          "HTML5",
+          "CSS3 (SCSS)",
+          "JavaScript",
+          "jQuery",
+          "Vue.js",
+        ],
+        note: "Focused on frontend for the past year and a half. I also enjoy UI/UX reading to sharpen design taste.",
+      },
+      {
+        title: "Backend",
+        subtitle: "Web Backend",
+        items: ["C# (WinForm · WebForm · MVC)", "PHP (CodeIgniter)", "Node.js"],
+        note: "Built e-commerce sites and integrated payment gateways (Pay2go / NewebPay, allPay / ECPay).",
+      },
+      {
+        title: "Database & Systems",
+        subtitle: "Infrastructure",
+        items: [
+          "MySQL",
+          "MSSQL",
+          "MongoDB",
+          "Windows Server",
+          "Linux (Ubuntu · Fedora)",
+        ],
+        note: "Hands-on with both major platforms, including service setup and deployment.",
+      },
+      {
+        title: "Others",
+        subtitle: "Extras",
+        items: ["PhoneGap", "ChatBot", "Adobe Illustrator", "Adobe Photoshop"],
+        note: "Explored chatbot projects and took Illustrator / Photoshop design courses.",
+      },
+    ],
+  },
+  projects: {
+    title: "Projects",
+    subtitle: "Featured Works",
+    items: [
+      {
+        name: "Solar Citizen Power Plant",
+        description:
+          "Built a solar purchase platform with C# ASP.NET WebForm, payment integration, and support for credit cards and ATM transfers.",
+        tech: [
+          "C# ASP.NET WebForm",
+          "HTML5",
+          "CSS3",
+          "MSSQL",
+          "Pay2go",
+          "Google Cloud",
+          "Win Server",
+        ],
+      },
+      {
+        name: "DMS ATM monitoring + deposit machine admin refresh",
+        description:
+          "Helped upgrade a legacy ASP project to ASP.NET, redesigned the HTML5 UI, and optimized SQL stored procedure performance.",
+        tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "CSS3", "jQuery"],
+      },
+      {
+        name: "Relay parking — marketing site",
+        description:
+          "Custom responsive marketing site built with HTML5, CSS3, and JavaScript.",
+        tech: ["HTML5", "CSS3", "JavaScript", "jQuery"],
+      },
+      {
+        name: "Haoyun Leasing — marketing site",
+        description:
+          "C# ASP.NET WebForm marketing site with a CMS for client editing, hosted on AWS.",
+        tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "jQuery", "AWS Cloud"],
+      },
+      {
+        name: "Paper-roll automated printing system",
+        description:
+          "C# WinForm industrial control flow integrated with PLC and sensors for reports and production history.",
+        tech: ["C# WinForm", "MSSQL", "MySQL", "SQLite", "SAP ERP", "PLC"],
+      },
+    ],
+  },
+  blog: {
+    metaTitle: "Blog — Steven Weng",
+    metaDescription: "Writing about React, TypeScript, and frontend engineering.",
+    title: "Blog",
+    subtitle: "Frontend engineering notes",
+    empty: "No posts yet. Check back soon.",
+    back: "Back to Blog",
+  },
+};
+
+export default en;

--- a/dictionaries/types.ts
+++ b/dictionaries/types.ts
@@ -1,0 +1,68 @@
+export interface Dictionary {
+  meta: {
+    title: string;
+    description: string;
+  };
+  nav: {
+    brand: string;
+    about: string;
+    experience: string;
+    skills: string;
+    projects: string;
+    blog: string;
+    localeEn: string;
+    localeZh: string;
+  };
+  footer: {
+    copyright: string;
+  };
+  hero: {
+    experienceLabel: string;
+    coreStackLabel: string;
+    available: string;
+    greeting: string;
+    name: string;
+    tagline: string;
+    bio: string[];
+    quote: string;
+    companies: string[];
+    stack: string[];
+    photoAlt: string;
+  };
+  experience: {
+    title: string;
+    subtitle: string;
+    jobs: {
+      period: string;
+      company: string;
+      roles: { title: string; description: string }[];
+    }[];
+  };
+  skills: {
+    title: string;
+    subtitle: string;
+    categories: {
+      title: string;
+      subtitle: string;
+      items: string[];
+      note: string;
+    }[];
+  };
+  projects: {
+    title: string;
+    subtitle: string;
+    items: {
+      name: string;
+      description: string;
+      tech: string[];
+    }[];
+  };
+  blog: {
+    metaTitle: string;
+    metaDescription: string;
+    title: string;
+    subtitle: string;
+    empty: string;
+    back: string;
+  };
+}

--- a/dictionaries/zh.ts
+++ b/dictionaries/zh.ts
@@ -1,0 +1,243 @@
+import type { Dictionary } from "./types";
+
+const zh: Dictionary = {
+  meta: {
+    title: "Steven Weng — 前端工程師",
+    description: "翁于宸（Steven Weng）的個人履歷與部落格，高階前端工程師。",
+  },
+  nav: {
+    brand: "Steven Weng",
+    about: "關於",
+    experience: "經歷",
+    skills: "技能",
+    projects: "專案",
+    blog: "部落格",
+    localeEn: "EN",
+    localeZh: "中文",
+  },
+  footer: {
+    copyright: "Steven Weng · 以 Next.js 與 Tailwind CSS 建置",
+  },
+  hero: {
+    experienceLabel: "經歷",
+    coreStackLabel: "核心技術",
+    available: "可承接新專案",
+    greeting: "你好，我是",
+    name: "Steven Weng",
+    tagline:
+      "高階前端工程師，專注打造快速、可及且視覺出色的數位體驗。",
+    bio: [
+      "嗨！我是于宸 Steven，目前擔任高階前端工程師。擁有豐富的工業控制系統與網頁開發經驗，專注於 React、TypeScript 以及高效能應用的架構設計。",
+      "除了開發工作，我也熱衷於社群貢獻，曾參與多場技術年會與社群活動，致力於持續學習最新的前端技術與最佳實踐。",
+    ],
+    quote:
+      "我相信好的設計是盡可能少的設計。專注乾淨的程式碼、穩定節奏，以及以使用者為中心的解決方案。",
+    companies: ["Placements.io", "4IDPS", "三商電腦", "鵬柏科技", "專智科技"],
+    stack: ["React", "TypeScript", "Node.js", "Next.js", "C#", "Tailwind"],
+    photoAlt: "翁于宸 Steven Weng",
+  },
+  experience: {
+    title: "工作經歷",
+    subtitle: "職涯軌跡",
+    jobs: [
+      {
+        period: "2020.09 — 2026.03",
+        company: "Placements.io",
+        roles: [
+          {
+            title: "高階前端工程師",
+            description:
+              "主導營收管理平台的前端架構決策，建立可擴充、可維護的 React 應用模式，服務企業客戶。",
+          },
+          {
+            title: "大規模資料儀表板優化",
+            description:
+              "設計並優化處理數百萬筆廣告花費資料的高效能儀表板，透過虛擬化、memoization 與高效 API 分頁降低載入時間。",
+          },
+          {
+            title: "導師制與團隊成長",
+            description:
+              "透過 code review、結對程式設計與內部技術分享，指導初階與中階工程師 React、TypeScript 與前端最佳實踐。",
+          },
+          {
+            title: "跨職能協作",
+            description:
+              "與產品、設計與後端緊密合作，交付端到端功能——從 API 契約設計、精準 UI 實作到 QA 驗收。",
+          },
+        ],
+      },
+      {
+        period: "2018.12 — 2020.09",
+        company: "4IDPS 我愛數位科技",
+        roles: [
+          {
+            title: "獨立負責 MES 系統開發",
+            description:
+              "包含系統規劃、設計、執行。技術使用 NodeJS + Oracle 搭配前端 React + Redux。",
+          },
+          {
+            title: "負責 Nextmile 網站前後端開發",
+            description:
+              "技術包含：AWS Serverless (Amplify, DynamoDB, AppSync, S3), React + GraphQL。",
+          },
+          {
+            title: "負責 LevelHeroes 網站前端開發",
+            description:
+              "技術包含：React, CSS-in-JS (Styled Components), Hooks, Storybook。",
+          },
+          {
+            title: "內部訓練經驗分享",
+            description: "CSS、React、JavaScript 等技術分享，以及專案經驗分享。",
+          },
+        ],
+      },
+      {
+        period: "2017-08 — 2018-12",
+        company: "三商電腦",
+        roles: [
+          {
+            title: "入金系統專案維護與需求開發",
+            description:
+              "包含 ASP.NET 維護、排程作業維護、MSSQL Stored Procedure 維護更新及備份。",
+          },
+          {
+            title: "ATM 監控系統翻新",
+            description: "協助將 ASP 舊專案升級至 ASP.NET。",
+          },
+          {
+            title: "導入前後端分離架構",
+            description:
+              "協助評估 VueJS，進行基礎教育訓練，建置前後端分離的開發架構。",
+          },
+        ],
+      },
+      {
+        period: "2016-03 — 2017-08",
+        company: "鵬柏科技",
+        roles: [
+          {
+            title: "台中正隆紙廠產線自動化系統開發",
+            description:
+              "使用 C# 開發桌面程式及硬體通訊程式，整合 SAP ERP 系統達到自動生產入庫。",
+          },
+          {
+            title: "印尼 Fajar Paper 紙廠自動化系統開發",
+            description: "負責兩套程式開發以及印尼現場作業規劃、會議進行。",
+          },
+          {
+            title: "蘇花改灌漿機程式開發",
+            description:
+              "使用 C# 串接印表機及 Sensor 設備，紀錄灌漿資料至 SQLite 並即時列印數據。",
+          },
+        ],
+      },
+      {
+        period: "2014 — 2015",
+        company: "專智科技",
+        roles: [
+          {
+            title: "電商網站維護",
+            description:
+              "接觸正在運行的 VB.NET / PHP 專案，學習 Linux 伺服器架設、CRM 系統維護、前端 jQuery 開發及 PhoneGap APP 開發。",
+          },
+        ],
+      },
+    ],
+  },
+  skills: {
+    title: "專業技能",
+    subtitle: "技術武器庫",
+    categories: [
+      {
+        title: "網頁前端",
+        subtitle: "Frontend",
+        items: [
+          "React + Redux (Redux Thunk)",
+          "HTML5",
+          "CSS3 (SCSS)",
+          "JavaScript",
+          "jQuery",
+          "Vue.js",
+        ],
+        note: "近一年半多專注於前端開發。本身也喜歡閱讀 UI/UX 相關文章，提升設計美感。",
+      },
+      {
+        title: "網頁後端",
+        subtitle: "Backend",
+        items: ["C# (WinForm · WebForm · MVC)", "PHP (CodeIgniter)", "Node.js"],
+        note: "開發過電商網站，串接過金流（智付通、歐付寶）。",
+      },
+      {
+        title: "資料庫 · 系統",
+        subtitle: "Database & Systems",
+        items: [
+          "MySQL",
+          "MSSQL",
+          "MongoDB",
+          "Windows Server",
+          "Linux (Ubuntu · Fedora)",
+        ],
+        note: "兩大平台都有接觸，包含服務的架設部署。",
+      },
+      {
+        title: "其他",
+        subtitle: "Others",
+        items: ["PhoneGap", "ChatBot", "Adobe Illustrator", "Adobe Photoshop"],
+        note: "玩過 Chatbot 聊天機器人，也修過 Illustrator、Photoshop 設計相關課程。",
+      },
+    ],
+  },
+  projects: {
+    title: "專案經驗",
+    subtitle: "精選作品",
+    items: [
+      {
+        name: "太陽人全民電廠",
+        description:
+          "使用 C# ASP.NET WebForm 架構開發，建置太陽能購買平台，串接金流服務，支援信用卡及 ATM 轉帳。",
+        tech: [
+          "C# ASP.NET WebForm",
+          "HTML5",
+          "CSS3",
+          "MSSQL",
+          "智付通金流",
+          "Google Cloud",
+          "Win Server",
+        ],
+      },
+      {
+        name: "DMS 提款機監控 + 入金機後台翻新",
+        description:
+          "協助將 ASP 舊專案更新至 ASP.NET，重新設計 HTML5 前端介面，並優化 SQL Stored Procedure 查詢效能。",
+        tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "CSS3", "jQuery"],
+      },
+      {
+        name: "Relay 驛站停車場 — 形象網站",
+        description: "純前端客製化響應式形象網站，使用 HTML5、CSS3、JavaScript 開發。",
+        tech: ["HTML5", "CSS3", "JavaScript", "jQuery"],
+      },
+      {
+        name: "豪運租賃 — 形象網站",
+        description:
+          "使用 C# ASP.NET WebForm 建置前端形象網站，含後台供客戶自行編輯頁面內容，架設於 AWS 雲端。",
+        tech: ["C# ASP.NET WebForm", "MSSQL", "HTML5", "jQuery", "AWS Cloud"],
+      },
+      {
+        name: "紙捲自動化噴印系統",
+        description:
+          "使用 C# WinForm 開發工業控制自動流程，配合 PLC 及各類 Sensor 獲取資料，整合至系統產生報表與生產履歷。",
+        tech: ["C# WinForm", "MSSQL", "MySQL", "SQLite", "SAP ERP", "PLC"],
+      },
+    ],
+  },
+  blog: {
+    metaTitle: "部落格 — Steven Weng",
+    metaDescription: "關於 React、TypeScript 與前端工程的筆記。",
+    title: "部落格",
+    subtitle: "前端工程筆記",
+    empty: "目前尚無文章，稍後再來看看。",
+    back: "回到部落格",
+  },
+};
+
+export default zh;

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,46 @@
+import type { Dictionary } from "@/dictionaries/types";
+
+export const locales = ["en", "zh"] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = "en";
+
+export const localeHtmlLang: Record<Locale, string> = {
+  en: "en",
+  zh: "zh-TW",
+};
+
+export const isLocale = (value: string): value is Locale =>
+  locales.includes(value as Locale);
+
+export const getDictionary = async (locale: Locale): Promise<Dictionary> => {
+  switch (locale) {
+    case "zh":
+      return (await import("@/dictionaries/zh")).default;
+    case "en":
+    default:
+      return (await import("@/dictionaries/en")).default;
+  }
+};
+
+/** Path for Next.js Link/router (basePath is applied by Next automatically). */
+export const localizedHref = (locale: Locale, path = "/"): string => {
+  if (path === "/" || path === "") {
+    return `/${locale}/`;
+  }
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
+  return `/${locale}${withSlash}`;
+};
+
+export const swapLocaleInPathname = (pathname: string, nextLocale: Locale): string => {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) {
+    return localizedHref(nextLocale, "/");
+  }
+  if (isLocale(segments[0])) {
+    segments[0] = nextLocale;
+  } else {
+    segments.unshift(nextLocale);
+  }
+  return `/${segments.join("/")}/`;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add bilingual support with shared components and locale dictionaries. Default language is English.

## Changes

- Add `dictionaries/en.ts` and `dictionaries/zh.ts` plus `lib/i18n.ts`
- Move pages under `app/[lang]/` (`/en/`, `/zh/`) with static generation
- Wire Hero / Experience / Skills / Projects / Navbar / Blog chrome to dictionaries
- Add navbar `EN` / `中文` toggle that preserves the current path
- Root `/` redirects to `/Resume/en/` for GitHub Pages

## Description of the change

> Build-time static HTML is generated for both locales. Editing stays i18n-based: one component tree, language strings in dictionaries. Blog post markdown bodies remain English in v1; only UI chrome is localized.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

