### PR TITLE
BUGFIX - Disable trailingSlash for GitHub Pages locale routes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { defaultLocale, localizedHref } from "@/lib/i18n";
 
 export default function RootPage() {
   const href = localizedHref(defaultLocale, "/");
-  const refreshTarget = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/${defaultLocale}/`;
+  const refreshTarget = `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/${defaultLocale}`;
 
   return (
     <main className="min-h-[50vh] flex flex-col items-center justify-center gap-4 px-6 text-center">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -17,10 +17,7 @@ interface NavbarProps {
 export default function Navbar({ locale, labels }: NavbarProps) {
   const pathname = usePathname() || "/";
   const homeHref = localizedHref(locale, "/");
-  const isHome =
-    pathname === homeHref ||
-    pathname === `/${locale}` ||
-    pathname === `/${locale}/`;
+  const isHome = pathname === homeHref || pathname === `/${locale}`;
   const [scrolled, setScrolled] = useState(false);
 
   const sections = [

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -25,11 +25,10 @@ export const getDictionary = async (locale: Locale): Promise<Dictionary> => {
 /** Path for Next.js Link/router (basePath is applied by Next automatically). */
 export const localizedHref = (locale: Locale, path = "/"): string => {
   if (path === "/" || path === "") {
-    return `/${locale}/`;
+    return `/${locale}`;
   }
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
-  return `/${locale}${withSlash}`;
+  return `/${locale}${normalized.replace(/\/$/, "")}`;
 };
 
 export const swapLocaleInPathname = (pathname: string, nextLocale: Locale): string => {
@@ -42,5 +41,5 @@ export const swapLocaleInPathname = (pathname: string, nextLocale: Locale): stri
   } else {
     segments.unshift(nextLocale);
   }
-  return `/${segments.join("/")}/`;
+  return `/${segments.join("/")}`;
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  trailingSlash: true,
+  // GitHub Pages artifact adapter serves `en.html` (not `en/index.html`),
+  // so trailing-slash URLs 404 in production.
+  trailingSlash: false,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
   images: { unoptimized: true },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Locale pages 404'd with trailing slashes because the GitHub Pages artifact serves `en.html` / `zh.html`.

## Changes

- Set `trailingSlash: false` in `next.config.ts`
- Align locale href helpers and root redirect with non-trailing-slash URLs

## Description of the change

> After adding `/en` and `/zh` routes, `/Resume/en/` returned 404 while `/Resume/en` worked. This matches the Pages adapter output (`en.html`). Disabling trailingSlash makes generated links match production URLs.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Follow-up to PR #11

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9c78-c240-7193-b2a7-c398ac861d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

